### PR TITLE
[Feature] 리프레시 관련 API, 로직 수정, 테스트를 위한 일반 로그인/ 회원가입 구현

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,6 +12,7 @@ model User {
   email            String             @unique
   name             String
   nickname         String
+  password         String?
   auth_provider    String
   profile_url      String?
   role_id          Int
@@ -25,11 +26,14 @@ model User {
   created_at       DateTime           @default(now())
   updated_at       DateTime           @updatedAt
   ArtistData       ArtistData?
+  Channel_users    Channel_users[]
   FeedComments     FeedComment[]
   FeedLikes        FeedLike[]
   FeedPosts        FeedPost[]
   Followed         Follows[]          @relation("FollowedUsers")
   Follows          Follows[]          @relation("UserFollows")
+  Message          Message[]
+  Message_status   Message_status[]
   ProgrammerData   ProgrammerData?
   ProjectPosts     Project?
   ProjectPost      ProjectPost[]
@@ -40,9 +44,6 @@ model User {
   UserApplyProject UserApplyProject[]
   UserLinks        UserLink[]
   UserSkills       UserSkill[]
-  Channel_users    Channel_users[]
-  Message          Message[]
-  Message_status   Message_status[]
 
   @@index([role_id], map: "User_role_id_fkey")
   @@index([status_id], map: "User_status_id_fkey")
@@ -309,7 +310,7 @@ model UserApplyProject {
 }
 
 model Channel {
-  id            String          @id
+  id            Int             @id @default(autoincrement())
   name          String          @default("default_channel_name")
   active        Boolean         @default(true)
   created_at    DateTime        @default(now())
@@ -319,23 +320,29 @@ model Channel {
 
 model Channel_users {
   id         Int      @id @default(autoincrement())
-  channel_id String
+  channel_id Int
   user_id    Int
   joined_at  DateTime @default(now())
   channel    Channel  @relation(fields: [channel_id], references: [id])
   user       User     @relation(fields: [user_id], references: [id])
+
+  @@index([channel_id], map: "Channel_users_channel_id_fkey")
+  @@index([user_id], map: "Channel_users_user_id_fkey")
 }
 
 model Message {
   id             Int              @id @default(autoincrement())
-  channel_id     String
   user_id        Int
-  type           String
-  content        String
   created_at     DateTime         @default(now())
-  user           User             @relation(fields: [user_id], references: [id])
+  channel_id     Int
+  content        String
+  type           String
   channel        Channel          @relation(fields: [channel_id], references: [id])
+  user           User             @relation(fields: [user_id], references: [id])
   message_status Message_status[]
+
+  @@index([channel_id], map: "Message_channel_id_fkey")
+  @@index([user_id], map: "Message_user_id_fkey")
 }
 
 model Message_status {
@@ -343,7 +350,9 @@ model Message_status {
   message_id Int
   user_id    Int
   is_read    Boolean @default(false)
-  user       User    @relation(fields: [user_id], references: [id])
   message    Message @relation(fields: [message_id], references: [id])
-}
+  user       User    @relation(fields: [user_id], references: [id])
 
+  @@index([message_id], map: "Message_status_message_id_fkey")
+  @@index([user_id], map: "Message_status_user_id_fkey")
+}

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -8,6 +8,7 @@ import {
   Put,
   HttpException,
   Res,
+  HttpStatus,
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { AuthService } from '@src/modules/auth/auth.service';
@@ -37,28 +38,17 @@ export class AuthController {
       await this.authService.handleGoogleCallback(code);
     console.log('accessToken: ' + accessToken);
     console.log('refreshToken: ' + refreshToken);
-    // 리프레시 토큰을 HTTP-Only 쿠키로 설정
-    res.cookie('refreshToken', refreshToken, {
-      httpOnly: false,
-      secure: false,
-      sameSite: 'none',
-      path: '/',
-      maxAge: 7 * 24 * 60 * 60,
-    });
-
-    return res.status(HttpStatusCodes.OK).json(
-      new ApiResponse(HttpStatusCodes.OK, 'Google 로그인 성공', {
-        user,
-        accessToken,
-        refreshToken,
-        isExistingUser,
-      })
-    );
-    // return new ApiResponse(HttpStatusCodes.OK, 'Google 로그인 성공', {
-    //   user,
-    //   accessToken,
-    //   isExistingUser,
-    // });
+    const response = {
+      message: {
+        code: 200,
+        message: 'Google 로그인 성공',
+      },
+      user,
+      accessToken,
+      isExistingUser,
+    };
+    console.log(response);
+    return res.status(HttpStatusCodes.OK).json(response);
   }
 
   @Get('github')
@@ -70,22 +60,19 @@ export class AuthController {
   @Post('github/callback')
   async githubCallback(@Body('code') code: string, @Res() res: Response) {
     // Authorization Code 교환 및 사용자 정보 가져오기
-    const { user, accessToken, refreshToken, isExistingUser } =
+    const { user, accessToken, isExistingUser } =
       await this.authService.handleGithubCallback(code);
-
-    // 리프레시 토큰을 HTTP-Only 쿠키로 설정
-    res.cookie('refreshToken', refreshToken, {
-      httpOnly: true,
-      secure: true,
-      sameSite: 'strict', // CSRF 방지
-      maxAge: 7 * 24 * 60 * 60, // 7일
-    });
-
-    return new ApiResponse(HttpStatusCodes.OK, 'Google 로그인 성공', {
+    const response = {
+      message: {
+        code: 200,
+        message: 'Google 로그인 성공',
+      },
       user,
       accessToken,
       isExistingUser,
-    });
+    };
+    console.log(response);
+    return res.status(HttpStatusCodes.OK).json(response);
   }
 
   // Role 선택 API
@@ -110,125 +97,115 @@ export class AuthController {
     return res.status(HttpStatusCodes.OK).json(responseBody);
   }
 
+  @Post('refresh')
+  async refreshAccessToken(
+    @Body('user_id') userId: number, // user_id는 숫자로 받음
+    @Res() res: Response
+  ) {
+    if (userId === undefined || userId === null) {
+      throw new HttpException('User ID is required', HttpStatus.BAD_REQUEST);
+    }
+    console.log(userId);
+    try {
+      // user_id를 문자열로 변환
+      //const userIdStr = String(userId);
+
+      // 리프레쉬 토큰 확인 및 액세스 토큰 재발급
+      const newAccessToken = await this.authService.renewAccessToken(userId);
+
+      // 성공 메시지와 새로운 액세스 토큰 반환
+      const response = {
+        message: {
+          code: 200,
+          text: 'Access token이 성공적으로 갱신 되었습니다.',
+        },
+        access_token: newAccessToken,
+      };
+
+      return res.status(200).json(response);
+    } catch (error) {
+      //throw new HttpException(error.message, HttpStatus.UNAUTHORIZED);
+      console.log(error);
+    }
+  }
+
   // @Post('refresh')
   // async refreshAccessToken(@Req() req: any, @Res() res: Response) {
   //   console.log('Refresh Token API 호출');
   //   const refreshToken = req.cookies['refreshToken'];
-  //
+  //   console.log('refreshToken from Cookie: ' + refreshToken);
+  //   // 1. Refresh Token이 없는 경우 예외 처리
   //   if (!refreshToken) {
+  //     console.error('리프레쉬 토큰 없음');
   //     throw new HttpException(
   //       ErrorMessages.AUTH.INVALID_REFRESH_TOKEN.text,
   //       ErrorMessages.AUTH.INVALID_REFRESH_TOKEN.code
   //     );
   //   }
-  //   //const userId = req.user?.user_id;
-  //   const userId = this.authService.getUserIdFromRefreshToken(refreshToken);
-  //   console.log('user_id: ' + userId);
-  //   const isValid = await this.authService.validateRefreshToken(
-  //     userId,
-  //     refreshToken
-  //   );
-  //   if (!isValid) {
-  //     const error = ErrorMessages.AUTH.INVALID_REFRESH_TOKEN;
-  //     throw new HttpException(error.text, error.code);
-  //   }
+  //   console.log('요청된 Refresh Token:', refreshToken);
   //
-  //   const newAccessToken = this.authService.generateAccessToken(userId);
-  //   const newRefreshToken = this.authService.generateRefreshToken(userId);
-  //   res.cookie('refreshToken', newRefreshToken, {
-  //     httpOnly: true,
-  //     secure: false,
-  //     sameSite: 'none',
-  //     maxAge: 7 * 24 * 60 * 60 * 1000,
-  //   });
-  //   return res.status(HttpStatusCodes.OK).json(
-  //     new ApiResponse(
-  //       HttpStatusCodes.OK,
-  //       '액세스 토큰이 성공적으로 갱신되었습니다.',
-  //       {
-  //         accessToken: newAccessToken,
-  //       }
-  //     )
-  //   );
+  //   try {
+  //     // 2. Refresh Token에서 User ID 추출
+  //     const userId = this.authService.getUserIdFromRefreshToken(refreshToken);
+  //     if (!userId) {
+  //       console.error('Refresh Token으로부터 User ID 추출 실패');
+  //       throw new HttpException(
+  //         ErrorMessages.AUTH.INVALID_REFRESH_TOKEN.text,
+  //         ErrorMessages.AUTH.INVALID_REFRESH_TOKEN.code
+  //       );
+  //     }
+  //     console.log('추출된 User ID:', userId);
+  //
+  //     // 3. Refresh Token 유효성 검증
+  //     const isValid = await this.authService.validateRefreshToken(
+  //       userId,
+  //       refreshToken
+  //     );
+  //     console.log('Refresh Token 유효성 검증 결과:', isValid);
+  //
+  //     if (!isValid) {
+  //       console.error('Refresh Token이 Redis와 일치하지 않음');
+  //       throw new HttpException(
+  //         ErrorMessages.AUTH.INVALID_REFRESH_TOKEN.text,
+  //         ErrorMessages.AUTH.INVALID_REFRESH_TOKEN.code
+  //       );
+  //     }
+  //
+  //     // 4. 새로운 Access Token 및 Refresh Token 생성
+  //     const newAccessToken = this.authService.generateAccessToken(userId);
+  //     const newRefreshToken = this.authService.generateRefreshToken(userId);
+  //
+  //     console.log('새로운 Access Token:', newAccessToken);
+  //     console.log('새로운 Refresh Token:', newRefreshToken);
+  //
+  //     // 5. Redis에 새로운 Refresh Token 저장
+  //     await this.authService.storeRefreshToken(userId, newRefreshToken);
+  //
+  //     // 6. Refresh Token을 쿠키에 저장
+  //     res.cookie('refreshToken', refreshToken, {
+  //       httpOnly: false,
+  //       secure: false,
+  //       sameSite: 'none',
+  //       path: '/',
+  //       maxAge: 7 * 24 * 60 * 60,
+  //     });
+  //
+  //     return res.status(HttpStatusCodes.OK).json(
+  //       new ApiResponse(
+  //         HttpStatusCodes.OK,
+  //         '액세스 토큰이 성공적으로 갱신되었습니다.',
+  //         {
+  //           accessToken: newAccessToken,
+  //         }
+  //       )
+  //     );
+  //   } catch (error) {
+  //     console.error('Refresh Token 갱신 중 오류 발생:', error.message);
+  //     return res.status(HttpStatusCodes.INTERNAL_SERVER_ERROR).json({
+  //       message: 'Internal Server Error',
+  //     });
+  //   }
   // }
-
-  @Post('refresh')
-  async refreshAccessToken(@Req() req: any, @Res() res: Response) {
-    console.log('Refresh Token API 호출');
-    const refreshToken = req.cookies['refreshToken'];
-    console.log('refreshToken from Cookie: ' + refreshToken);
-    // 1. Refresh Token이 없는 경우 예외 처리
-    if (!refreshToken) {
-      console.error('리프레쉬 토큰 없음');
-      throw new HttpException(
-        ErrorMessages.AUTH.INVALID_REFRESH_TOKEN.text,
-        ErrorMessages.AUTH.INVALID_REFRESH_TOKEN.code
-      );
-    }
-    console.log('요청된 Refresh Token:', refreshToken);
-
-    try {
-      // 2. Refresh Token에서 User ID 추출
-      const userId = this.authService.getUserIdFromRefreshToken(refreshToken);
-      if (!userId) {
-        console.error('Refresh Token으로부터 User ID 추출 실패');
-        throw new HttpException(
-          ErrorMessages.AUTH.INVALID_REFRESH_TOKEN.text,
-          ErrorMessages.AUTH.INVALID_REFRESH_TOKEN.code
-        );
-      }
-      console.log('추출된 User ID:', userId);
-
-      // 3. Refresh Token 유효성 검증
-      const isValid = await this.authService.validateRefreshToken(
-        userId,
-        refreshToken
-      );
-      console.log('Refresh Token 유효성 검증 결과:', isValid);
-
-      if (!isValid) {
-        console.error('Refresh Token이 Redis와 일치하지 않음');
-        throw new HttpException(
-          ErrorMessages.AUTH.INVALID_REFRESH_TOKEN.text,
-          ErrorMessages.AUTH.INVALID_REFRESH_TOKEN.code
-        );
-      }
-
-      // 4. 새로운 Access Token 및 Refresh Token 생성
-      const newAccessToken = this.authService.generateAccessToken(userId);
-      const newRefreshToken = this.authService.generateRefreshToken(userId);
-
-      console.log('새로운 Access Token:', newAccessToken);
-      console.log('새로운 Refresh Token:', newRefreshToken);
-
-      // 5. Redis에 새로운 Refresh Token 저장
-      await this.authService.storeRefreshToken(userId, newRefreshToken);
-
-      // 6. Refresh Token을 쿠키에 저장
-      res.cookie('refreshToken', refreshToken, {
-        httpOnly: false,
-        secure: false,
-        sameSite: 'none',
-        path: '/',
-        maxAge: 7 * 24 * 60 * 60,
-      });
-
-      return res.status(HttpStatusCodes.OK).json(
-        new ApiResponse(
-          HttpStatusCodes.OK,
-          '액세스 토큰이 성공적으로 갱신되었습니다.',
-          {
-            accessToken: newAccessToken,
-          }
-        )
-      );
-    } catch (error) {
-      console.error('Refresh Token 갱신 중 오류 발생:', error.message);
-      return res.status(HttpStatusCodes.INTERNAL_SERVER_ERROR).json({
-        message: 'Internal Server Error',
-      });
-    }
-  }
 
   @Post('logout')
   async logout(@Req() req: any, @Res() res: Response) {

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -15,7 +15,6 @@ import { AuthService } from '@src/modules/auth/auth.service';
 import { JwtAuthGuard } from '@src/modules/auth/guards/jwt-auth.guard';
 import { JwtService } from '@nestjs/jwt';
 import { ApiResponse } from '@common/dto/response.dto';
-import { ErrorMessages } from '@common/constants/error-messages';
 import { HttpStatusCodes } from '@common/constants/http-status-code';
 import { Response } from 'express';
 @Controller('auth')
@@ -36,8 +35,7 @@ export class AuthController {
     // Authorization Code 교환 및 사용자 정보 가져오기
     const { user, accessToken, refreshToken, isExistingUser } =
       await this.authService.handleGoogleCallback(code);
-    console.log('accessToken: ' + accessToken);
-    console.log('refreshToken: ' + refreshToken);
+    console.log('refreshToken: ', refreshToken);
     const response = {
       message: {
         code: 200,
@@ -60,8 +58,9 @@ export class AuthController {
   @Post('github/callback')
   async githubCallback(@Body('code') code: string, @Res() res: Response) {
     // Authorization Code 교환 및 사용자 정보 가져오기
-    const { user, accessToken, isExistingUser } =
+    const { user, accessToken, refreshToken, isExistingUser } =
       await this.authService.handleGithubCallback(code);
+    console.log(refreshToken);
     const response = {
       message: {
         code: 200,
@@ -75,6 +74,10 @@ export class AuthController {
     return res.status(HttpStatusCodes.OK).json(response);
   }
 
+  // @Post('login')
+  // async login(
+  //   @Body()
+  // )
   // Role 선택 API
   @Put('roleselect')
   @UseGuards(JwtAuthGuard)
@@ -107,9 +110,6 @@ export class AuthController {
     }
     console.log(userId);
     try {
-      // user_id를 문자열로 변환
-      //const userIdStr = String(userId);
-
       // 리프레쉬 토큰 확인 및 액세스 토큰 재발급
       const newAccessToken = await this.authService.renewAccessToken(userId);
 
@@ -128,85 +128,6 @@ export class AuthController {
       console.log(error);
     }
   }
-
-  // @Post('refresh')
-  // async refreshAccessToken(@Req() req: any, @Res() res: Response) {
-  //   console.log('Refresh Token API 호출');
-  //   const refreshToken = req.cookies['refreshToken'];
-  //   console.log('refreshToken from Cookie: ' + refreshToken);
-  //   // 1. Refresh Token이 없는 경우 예외 처리
-  //   if (!refreshToken) {
-  //     console.error('리프레쉬 토큰 없음');
-  //     throw new HttpException(
-  //       ErrorMessages.AUTH.INVALID_REFRESH_TOKEN.text,
-  //       ErrorMessages.AUTH.INVALID_REFRESH_TOKEN.code
-  //     );
-  //   }
-  //   console.log('요청된 Refresh Token:', refreshToken);
-  //
-  //   try {
-  //     // 2. Refresh Token에서 User ID 추출
-  //     const userId = this.authService.getUserIdFromRefreshToken(refreshToken);
-  //     if (!userId) {
-  //       console.error('Refresh Token으로부터 User ID 추출 실패');
-  //       throw new HttpException(
-  //         ErrorMessages.AUTH.INVALID_REFRESH_TOKEN.text,
-  //         ErrorMessages.AUTH.INVALID_REFRESH_TOKEN.code
-  //       );
-  //     }
-  //     console.log('추출된 User ID:', userId);
-  //
-  //     // 3. Refresh Token 유효성 검증
-  //     const isValid = await this.authService.validateRefreshToken(
-  //       userId,
-  //       refreshToken
-  //     );
-  //     console.log('Refresh Token 유효성 검증 결과:', isValid);
-  //
-  //     if (!isValid) {
-  //       console.error('Refresh Token이 Redis와 일치하지 않음');
-  //       throw new HttpException(
-  //         ErrorMessages.AUTH.INVALID_REFRESH_TOKEN.text,
-  //         ErrorMessages.AUTH.INVALID_REFRESH_TOKEN.code
-  //       );
-  //     }
-  //
-  //     // 4. 새로운 Access Token 및 Refresh Token 생성
-  //     const newAccessToken = this.authService.generateAccessToken(userId);
-  //     const newRefreshToken = this.authService.generateRefreshToken(userId);
-  //
-  //     console.log('새로운 Access Token:', newAccessToken);
-  //     console.log('새로운 Refresh Token:', newRefreshToken);
-  //
-  //     // 5. Redis에 새로운 Refresh Token 저장
-  //     await this.authService.storeRefreshToken(userId, newRefreshToken);
-  //
-  //     // 6. Refresh Token을 쿠키에 저장
-  //     res.cookie('refreshToken', refreshToken, {
-  //       httpOnly: false,
-  //       secure: false,
-  //       sameSite: 'none',
-  //       path: '/',
-  //       maxAge: 7 * 24 * 60 * 60,
-  //     });
-  //
-  //     return res.status(HttpStatusCodes.OK).json(
-  //       new ApiResponse(
-  //         HttpStatusCodes.OK,
-  //         '액세스 토큰이 성공적으로 갱신되었습니다.',
-  //         {
-  //           accessToken: newAccessToken,
-  //         }
-  //       )
-  //     );
-  //   } catch (error) {
-  //     console.error('Refresh Token 갱신 중 오류 발생:', error.message);
-  //     return res.status(HttpStatusCodes.INTERNAL_SERVER_ERROR).json({
-  //       message: 'Internal Server Error',
-  //     });
-  //   }
-  // }
-
   @Post('logout')
   async logout(@Req() req: any, @Res() res: Response) {
     res.clearCookie('refreshToken'); // HTTP-Only 쿠키 삭제

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -129,8 +129,10 @@ export class AuthController {
     }
   }
   @Post('logout')
+  @UseGuards(JwtAuthGuard)
   async logout(@Req() req: any, @Res() res: Response) {
-    res.clearCookie('refreshToken'); // HTTP-Only 쿠키 삭제
+    const userId = req.user?.user_id;
+    await this.authService.deleteRefreshToken(userId);
     return res
       .status(HttpStatusCodes.OK)
       .json(new ApiResponse(HttpStatusCodes.OK, '로그아웃 성공'));

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -64,7 +64,7 @@ export class AuthController {
     const response = {
       message: {
         code: 200,
-        message: 'Google 로그인 성공',
+        message: 'Github 로그인 성공',
       },
       user,
       accessToken,

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -137,4 +137,29 @@ export class AuthController {
       .status(HttpStatusCodes.OK)
       .json(new ApiResponse(HttpStatusCodes.OK, '로그아웃 성공'));
   }
+
+  @Post('signup')
+  async signup(
+    @Body() body: { email: string; nickname: string; password: string }
+  ) {
+    const result = await this.authService.signup(
+      body.email,
+      body.nickname,
+      body.password
+    );
+    return {
+      message: 'Signup successful',
+      user: result,
+    };
+  }
+
+  @Post('login')
+  async login(@Body() body: { email: string; password: string }) {
+    const result = await this.authService.login(body.email, body.password);
+    return {
+      message: 'Login successful',
+      user: result.user,
+      access_token: result.accessToken,
+    };
+  }
 }

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -250,7 +250,7 @@ export class AuthService {
     console.log(`Access Token 생성: userId=${userId}`);
     return this.jwtService.sign(
       { userId },
-      { expiresIn: '15m', secret: process.env.ACCESS_TOKEN_SECRET }
+      { expiresIn: '7d', secret: process.env.ACCESS_TOKEN_SECRET }
     );
   }
 

--- a/src/modules/auth/strategies/jwt.strategy.ts
+++ b/src/modules/auth/strategies/jwt.strategy.ts
@@ -12,7 +12,6 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload: any) {
-    console.log('JWT_payload: ', payload);
     // req.user에 설정될 사용자 정보 반환
     return { user_id: payload.userId, email: payload.email };
   }


### PR DESCRIPTION
# 🚀 구현한 내용 (What was implemented)

<!-- 구현한 기능이나 변경 사항을 간략히 요약해주세요. -->
- ✨ 주요 기능:
  - [X] 기능 1: 기존의 리프레시 토큰 발급하는 API를 변경하였습니다
  - [X] 기능 2: 테스트를 위해 개발용 일반 로그인, 회원가입을 구현했습니다
  - [X] 기타: 서버 로깅을 위한 디버깅 문들을 여러곳에 배치하였습니다

---

# 🤔 논의가 필요한 사항 (Points to discuss)

<!-- 논의가 필요한 사항, 개선해야 할 부분을 작성해주세요. -->
- [X] 문제 1: 만약 소셜로그인시, 구글 이메일이랑 깃허브 이메일이랑 똑같으면 이미 가입된 유저로 로그인 시켜줘야 되는데 해당 부분이 구현 안되어있습니다

---

# 🖼️ 결과 이미지 (Screenshots)

<!-- 변경된 결과를 확인할 수 있는 스크린샷을 첨부해주세요. -->
| **일반 회원가입**                  | **일반 로그인**                  |
|-----------------------------|-----------------------------|
| <img width="335" alt="image" src="https://github.com/user-attachments/assets/7e81d5ad-bc2e-4c36-a7ff-cfcba7ba4259" />  | <img width="916" alt="image" src="https://github.com/user-attachments/assets/7482dea6-1e10-4921-8818-627308365822" /> |

---

# 🛠️ 추가 수정 필요 사항 (Additional fixes required)

<!-- PR에 포함되지 않았지만, 추가적으로 해야 할 작업이 있다면 작성해주세요. -->
- [ ] 수정 1: 리프레시 토큰 관련해서 개발 완료후 우선적으로 개선해야 할 점이 있습니다. (세션 스토리지, Body값 변경...)

---

# 📝 참고 사항 (Additional notes)

<!-- 테스트 방법, 관련 이슈, 참고 문서 등을 작성해주세요. -->
- **관련 이슈**: #9 , #16 
- **테스트 방법**:
  1. `일반 로그인` Body값 : 이메일, 비밀번호
  2. `일반 회원가입` Body값: 이메일 , 닉네임, 비밀번호
