### PR TITLE
채팅 서비스 / Socket.io를 사용한 1대1 채팅 및 HTTP API (채널 개별 조회, 채널 메세지 조회) 구현

### DIFF
--- a/prisma/migrations/20250114034707_online_users_table/migration.sql
+++ b/prisma/migrations/20250114034707_online_users_table/migration.sql
@@ -1,0 +1,11 @@
+-- AlterTable
+ALTER TABLE `User` ADD COLUMN `password` VARCHAR(191) NULL;
+
+-- CreateTable
+CREATE TABLE `online_users` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `client_id` VARCHAR(191) NOT NULL,
+    `user_id` INTEGER NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,7 +45,6 @@ model User {
   UserLinks        UserLink[]
   UserSkills       UserSkill[]
 
-
   @@index([role_id], map: "User_role_id_fkey")
   @@index([status_id], map: "User_status_id_fkey")
 }
@@ -356,4 +355,10 @@ model Message_status {
 
   @@index([message_id], map: "Message_status_message_id_fkey")
   @@index([user_id], map: "Message_status_user_id_fkey")
+}
+
+model online_users {
+  id        Int    @id @default(autoincrement())
+  client_id String
+  user_id   Int
 }

--- a/src/chat/chat.controller.spec.ts
+++ b/src/chat/chat.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ChatController } from './chat.controller';
+
+describe('ChatController', () => {
+  let controller: ChatController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ChatController],
+    }).compile();
+
+    controller = module.get<ChatController>(ChatController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/chat/chat.controller.ts
+++ b/src/chat/chat.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('chat')
+export class ChatController {}

--- a/src/chat/chat.controller.ts
+++ b/src/chat/chat.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Req, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, Query, Req, UseGuards } from '@nestjs/common';
 import { ChatService } from './chat.service';
 import { JwtAuthGuard } from '@src/modules/auth/guards/jwt-auth.guard';
 
@@ -12,6 +12,23 @@ export class ChatController {
   async getAllChannels(@Req() req: any) {
     const userId = +req.user.user_id;
     return this.chatService.getAllChannels(userId);
+  }
+
+  // 채널 메세지 조회
+  @Get('channels/:id/messages')
+  @UseGuards(JwtAuthGuard)
+  async getChannelsMessages(
+    @Req() req: any,
+    @Param('id') channelId: number,
+    @Query('limit') limit: number,
+    @Query('currentPage') currentPage: number
+  ) {
+    return await this.chatService.getMessages(
+      req.user.user_id,
+      +channelId,
+      +limit,
+      +currentPage
+    );
   }
 
   @Get('channels/:id')

--- a/src/chat/chat.controller.ts
+++ b/src/chat/chat.controller.ts
@@ -1,4 +1,16 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, Req, UseGuards } from '@nestjs/common';
+import { ChatService } from './chat.service';
+import { JwtAuthGuard } from '@src/modules/auth/guards/jwt-auth.guard';
 
 @Controller('chat')
-export class ChatController {}
+export class ChatController {
+  constructor(private readonly chatService: ChatService) {}
+
+  // 유저가 참여한 채널 전체 조회
+  @Get('channels')
+  @UseGuards(JwtAuthGuard)
+  async getAllChannels(@Req() req: any) {
+    const userId = +req.user.user_id;
+    return this.chatService.getAllChannels(userId);
+  }
+}

--- a/src/chat/chat.controller.ts
+++ b/src/chat/chat.controller.ts
@@ -33,7 +33,7 @@ export class ChatController {
 
   @Get('channels/:id')
   @UseGuards(JwtAuthGuard)
-  async getChannel(@Param('id') id: number) {
-    return this.chatService.getChannel(+id);
+  async getChannel(@Req() req: any, @Param('id') channelId: number) {
+    return this.chatService.getChannel(req.user.user_id, +channelId);
   }
 }

--- a/src/chat/chat.controller.ts
+++ b/src/chat/chat.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Req, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, Req, UseGuards } from '@nestjs/common';
 import { ChatService } from './chat.service';
 import { JwtAuthGuard } from '@src/modules/auth/guards/jwt-auth.guard';
 
@@ -12,5 +12,11 @@ export class ChatController {
   async getAllChannels(@Req() req: any) {
     const userId = +req.user.user_id;
     return this.chatService.getAllChannels(userId);
+  }
+
+  @Get('channels/:id')
+  @UseGuards(JwtAuthGuard)
+  async getChannel(@Param('id') id: number) {
+    return this.chatService.getChannel(+id);
   }
 }

--- a/src/chat/chat.gateway.ts
+++ b/src/chat/chat.gateway.ts
@@ -4,14 +4,34 @@ import {
   MessageBody,
   WebSocketServer,
   ConnectedSocket,
+  OnGatewayConnection,
+  OnGatewayDisconnect,
 } from '@nestjs/websockets';
 import { ChatService } from './chat.service';
 import { Server, Socket } from 'socket.io';
 
 @WebSocketGateway({ namespace: 'chat', cors: { origin: '*' } })
-export class ChatGateway {
+export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   constructor(private readonly chatService: ChatService) {}
+
   @WebSocketServer() server: Server;
+
+  // 유저 소켓 접속
+  async handleConnection(client: Socket) {
+    const userId = client.handshake.query.userId;
+    client.data.userId = userId;
+
+    await this.chatService.addUserOnline(userId, client.id);
+    console.log(`User ${userId} connected with socket ID ${client.id}`);
+  }
+
+  // 유저 소켓 접속 해제
+  handleDisconnect(client: Socket) {
+    console.log('유저 연결 해제', client.data.userId);
+    // 유저가 연결 끊을 때, 온라인 유저 목록에서 삭제
+    this.onlineUsers.delete(client.data.userId);
+  }
+
   // 채팅방 참여
   @SubscribeMessage('joinChannel')
   async handleJoinChannel(
@@ -25,12 +45,26 @@ export class ChatGateway {
 
     // 채널에 유저 참여
     client.join(channelId.toString());
-    const sockets = await this.server.fetchSockets(); // 연결된 모든 소켓 가져오기
-    const targetSocket = sockets.find(socket => socket.data.userId === userId2);
-    targetSocket.join(channelId.toString());
+    console.log(`client ${client.data.userId}  ${channelId}번 채팅방 입장`);
+
+    // B 유저 온라인 여부 확인
+    const targetSocket = this.onlineUsers.get(userId2.toString());
+    if (targetSocket) {
+      // 온라인
+      targetSocket.join(channelId.toString()); // B 유저도 채널에 입장
+      targetSocket.emit('channelJoined', { channelId: channelId.toString() });
+      console.log(
+        `client ${userId2} ${channelId}번 채팅방 입장 (온라인 바로 입장)`
+      );
+    } else {
+      // 오프라인
+      // 채팅 요청에 올려둠
+      this.chatRequest.set(userId2.toString(), channelId.toString());
+      console.log(`client ${userId2} 오프라인 `);
+    }
 
     // 클라이언트에 채널id 전달
-    this.server.emit('channelJoined', { channelId });
+    client.emit('channelJoined', { channelId: channelId.toString() });
   }
 
   // 메세지 송수신
@@ -60,7 +94,7 @@ export class ChatGateway {
 
     // 전달 데이터 양식
     const sendData = { ...resData, user, date };
-
+    console.log(sendData);
     this.server.to(data.channelId).emit('message', sendData);
   }
 }

--- a/src/chat/chat.gateway.ts
+++ b/src/chat/chat.gateway.ts
@@ -89,7 +89,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   // 채널 참여
   @SubscribeMessage('joinChannel')
   async handleJoinChannel(
-    @MessageBody() data: { userId: number; channelId: string },
+    @MessageBody() data: { userId: number; channelId: number },
     @ConnectedSocket() client: Socket
   ) {
     const { userId, channelId } = data;
@@ -112,7 +112,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
       type: string;
       content: string;
       userId: number;
-      channelId: string;
+      channelId: number;
     }
   ) {
     const { userId, ...resData } = data;
@@ -132,6 +132,6 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
     // 전달 데이터 양식
     const sendData = { ...resData, user, date };
     console.log(sendData);
-    this.server.to(data.channelId).emit('message', sendData);
+    this.server.to(data.channelId.toString()).emit('message', sendData);
   }
 }

--- a/src/chat/chat.gateway.ts
+++ b/src/chat/chat.gateway.ts
@@ -24,12 +24,15 @@ export class ChatGateway {
     const channelId = await this.chatService.getChannelId(userId1, userId2);
 
     // 채널에 유저 참여
-    client.to(userId1.toString()).socketsJoin(channelId.toString());
-    client.to(userId2.toString()).socketsJoin(channelId.toString());
+    client.join(channelId.toString());
+    const sockets = await this.server.fetchSockets(); // 연결된 모든 소켓 가져오기
+    const targetSocket = sockets.find(socket => socket.data.userId === userId2);
+    targetSocket.join(channelId.toString());
 
     // 클라이언트에 채널id 전달
     this.server.emit('channelJoined', { channelId });
   }
+
   // 메세지 송수신
   @SubscribeMessage('sendMessage')
   async handleSendMessage(

--- a/src/chat/chat.gateway.ts
+++ b/src/chat/chat.gateway.ts
@@ -127,6 +127,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
     // 유저 정보 추가
     const user = await this.chatService.getSenderProfile(userId);
+
     const date = new Date();
 
     // 전달 데이터 양식

--- a/src/chat/chat.gateway.ts
+++ b/src/chat/chat.gateway.ts
@@ -29,7 +29,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
     const channels = await this.chatService.getAllChannels(userId);
 
     // channel(유저가 참여한 전체 채널) 배열 형태로 전송
-    client.emit('fetchChanneles', channels);
+    client.emit('fetchChannels', channels);
   }
 
   // 유저 소켓 접속 해제

--- a/src/chat/chat.gateway.ts
+++ b/src/chat/chat.gateway.ts
@@ -68,10 +68,13 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
     // 온라인 일때
     if (targetSocket) {
       // 유저2의 소켓 가져오기
-      const user2Socket = this.server.sockets.sockets.get(
-        targetSocket.toString()
+      const sockets = await this.server.fetchSockets();
+      const user2Socket = sockets.find(
+        socket => socket.id === targetSocket.toString()
       );
+
       // 유저2의 채널 리스트에 해당 채널 추가
+      client.emit('channelAdded', channel);
       user2Socket.emit('channelAdded', channel);
       console.log(`channel ${channelId} added in ${userId2} channel list`);
     } else {
@@ -80,7 +83,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
     }
 
     // 클라이언트에 채널id 전달
-    client.emit('channelJoined', channel);
+    client.emit('channelCreated', channel);
   }
 
   // 채널 참여
@@ -92,8 +95,8 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
     const { userId, channelId } = data;
 
     // 채널 참여
-    client.join(channelId);
-
+    client.join(channelId.toString());
+    console.log(`유저 ${userId} 채널 ${channelId} 참여`);
     // 채널 객체
     const channel = { channelId };
 

--- a/src/chat/chat.module.ts
+++ b/src/chat/chat.module.ts
@@ -2,10 +2,12 @@ import { Module } from '@nestjs/common';
 import { ChatService } from './chat.service';
 import { PrismaModule } from '@src/prisma/prisma.module';
 import { JwtModule } from '@nestjs/jwt';
+import { ChatController } from './chat.controller';
 
 @Module({
   imports: [PrismaModule, JwtModule],
   providers: [ChatService],
   exports: [ChatService],
+  controllers: [ChatController],
 })
 export class ChatModule {}

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -108,7 +108,7 @@ export class ChatService {
 
       // 아닐 시 예외처리
       if (!auth.length) {
-        throw new Error();
+        throw new Error('권한 X');
       }
 
       // 채널 데이터 조회
@@ -157,7 +157,7 @@ export class ChatService {
       };
       return { channel, message };
     } catch (err) {
-      return err;
+      return err.message;
     }
   }
 
@@ -206,7 +206,7 @@ export class ChatService {
 
       // 아닐 시 예외처리
       if (!auth.length) {
-        throw new Error();
+        throw new Error('권한 X');
       }
 
       // 메세지 데이터 조회
@@ -262,7 +262,7 @@ export class ChatService {
       // 응답데이터 {메세지데이터, 페이지네이션}
       return { messages: data, pagenation, message };
     } catch (err) {
-      return err;
+      return err.message;
     }
   }
 }

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -130,4 +130,14 @@ export class ChatService {
       return err;
     }
   }
+
+  // 온라인 유저 DB에 저장
+  async addUserOnline(userId, clientId) {
+    await this.prisma.online_users.create({
+      data: {
+        user_id: userId,
+        client_id: clientId,
+      },
+    });
+  }
 }

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -99,8 +99,11 @@ export class ChatService {
       where: { user_id: id },
       select: { channel_id: true },
     });
+    const data = result.map(v => ({
+      channelId: v.channel_id,
+    }));
 
-    return result;
+    return data;
   }
 
   // 채널 개별 조회

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -5,6 +5,8 @@ import { PrismaService } from '@src/prisma/prisma.service';
 export class ChatService {
   constructor(private readonly prisma: PrismaService) {}
 
+  // ---- Socket ----
+
   // 채널 id를 리턴하는 로직
   async getChannelId(userId1, userId2) {
     // 매핑 테이블에서 파라미터로 전달된 유저 아이디에 해당하는 데이터 찾기
@@ -78,4 +80,20 @@ export class ChatService {
     return data;
   }
   // 메세지 상태 업데이트
+
+  // ---- HTTP ----
+
+  // 전체 조회
+  async getAllChannels(id: number) {
+    const result = await this.prisma.channel_users.findMany({
+      where: { user_id: id },
+      select: { channel_id: true },
+    });
+
+    const data = result.map(channel => ({
+      id: channel.channel_id,
+    }));
+
+    return data;
+  }
 }

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -152,7 +152,10 @@ export class ChatService {
       where: {
         user_id: userId,
       },
+      select: {
+        client_id: true,
+      },
     });
-    return socketId;
+    return socketId[0].client_id;
   }
 }

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -145,4 +145,14 @@ export class ChatService {
       },
     });
   }
+
+  // 유저 아이디를 통해 유저의 소켓 아이디 가져오기
+  async getSocketId(userId: number) {
+    const socketId = await this.prisma.online_users.findMany({
+      where: {
+        user_id: userId,
+      },
+    });
+    return socketId;
+  }
 }

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -63,7 +63,7 @@ export class ChatService {
 
   // 유저 정보 확인
   async getSenderProfile(userId) {
-    const data = await this.prisma.user.findUnique({
+    const result = await this.prisma.user.findUnique({
       where: {
         id: userId,
       },
@@ -77,6 +77,8 @@ export class ChatService {
         auth_provider: true,
       },
     });
+    const { id, ...resData } = result;
+    const data = { user_id: id, ...resData };
     return data;
   }
   // 메세지 상태 업데이트

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -222,28 +222,35 @@ export class ChatService {
       }
 
       // 메세지 데이터 조회
-      const result = await this.prisma.message.findMany({
-        where: {
-          channel_id: channelId,
-        },
-        include: {
-          user: {
-            select: {
-              id: true,
-              email: true,
-              name: true,
-              nickname: true,
-              role: true,
-              profile_url: true,
-              auth_provider: true,
+      const [result, totalMessageCount] = await Promise.all([
+        this.prisma.message.findMany({
+          where: {
+            channel_id: channelId,
+          },
+          include: {
+            user: {
+              select: {
+                id: true,
+                email: true,
+                name: true,
+                nickname: true,
+                role: true,
+                profile_url: true,
+                auth_provider: true,
+              },
             },
           },
-        },
-        orderBy: {
-          id: 'desc',
-        },
-        take: limit,
-      });
+          orderBy: {
+            id: 'desc',
+          },
+          take: limit,
+        }),
+        this.prisma.message.count({
+          where: {
+            channel_id: channelId,
+          },
+        }),
+      ]);
 
       // 메세지 데이터 양식화
       const data = result.map(msg => ({
@@ -262,7 +269,7 @@ export class ChatService {
       }));
       // 페이지네이션
       const pagenation = {
-        totalMessageCount: data.length,
+        totalMessageCount,
         currentPage: currentPage,
       };
 

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -77,8 +77,16 @@ export class ChatService {
         auth_provider: true,
       },
     });
-    const { id, ...resData } = result;
-    const data = { user_id: id, ...resData };
+
+    const data = {
+      userId: result.id,
+      email: result.email,
+      nickname: result.nickname,
+      profileUrl: result.profile_url,
+      authProvide: result.auth_provider,
+      roleId: result.role_id,
+    };
+
     return data;
   }
   // 메세지 상태 업데이트

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -83,18 +83,14 @@ export class ChatService {
 
   // ---- HTTP ----
 
-  // 전체 조회
+  // 유저가 참여한 채널 전체 조회
   async getAllChannels(id: number) {
     const result = await this.prisma.channel_users.findMany({
       where: { user_id: id },
       select: { channel_id: true },
     });
 
-    const data = result.map(channel => ({
-      id: channel.channel_id,
-    }));
-
-    return data;
+    return result;
   }
 
   async getChannel(channelId: number) {
@@ -137,6 +133,15 @@ export class ChatService {
       data: {
         user_id: userId,
         client_id: clientId,
+      },
+    });
+  }
+
+  // 오프라인 유저 DB에서 삭제
+  async deleteUserOnline(userId: number) {
+    await this.prisma.online_users.deleteMany({
+      where: {
+        user_id: userId,
       },
     });
   }

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -89,9 +89,38 @@ export class ChatService {
 
     return data;
   }
-  // 메세지 상태 업데이트
 
-  // ---- HTTP ----
+  // 온라인 유저 DB에 저장
+  async addUserOnline(userId, clientId) {
+    await this.prisma.online_users.create({
+      data: {
+        user_id: userId,
+        client_id: clientId,
+      },
+    });
+  }
+
+  // 오프라인 유저 DB에서 삭제
+  async deleteUserOnline(userId: number) {
+    await this.prisma.online_users.deleteMany({
+      where: {
+        user_id: userId,
+      },
+    });
+  }
+
+  // 유저 아이디를 통해 유저의 소켓 아이디 가져오기
+  async getSocketId(userId: number) {
+    const socketId = await this.prisma.online_users.findMany({
+      where: {
+        user_id: userId,
+      },
+      select: {
+        client_id: true,
+      },
+    });
+    return socketId[0].client_id;
+  }
 
   // 유저가 참여한 채널 전체 조회
   async getAllChannels(id: number) {
@@ -105,6 +134,10 @@ export class ChatService {
 
     return data;
   }
+
+  // 메세지 상태 업데이트
+
+  // ---- HTTP ----
 
   // 채널 개별 조회
   async getChannel(userId: number, channelId: number) {
@@ -170,38 +203,6 @@ export class ChatService {
     } catch (err) {
       return err.message;
     }
-  }
-
-  // 온라인 유저 DB에 저장
-  async addUserOnline(userId, clientId) {
-    await this.prisma.online_users.create({
-      data: {
-        user_id: userId,
-        client_id: clientId,
-      },
-    });
-  }
-
-  // 오프라인 유저 DB에서 삭제
-  async deleteUserOnline(userId: number) {
-    await this.prisma.online_users.deleteMany({
-      where: {
-        user_id: userId,
-      },
-    });
-  }
-
-  // 유저 아이디를 통해 유저의 소켓 아이디 가져오기
-  async getSocketId(userId: number) {
-    const socketId = await this.prisma.online_users.findMany({
-      where: {
-        user_id: userId,
-      },
-      select: {
-        client_id: true,
-      },
-    });
-    return socketId[0].client_id;
   }
 
   // 채널 메세지 조회

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -253,8 +253,14 @@ export class ChatService {
         totalMessageCount: data.length,
         currentPage: currentPage,
       };
+
+      const message = {
+        code: 200,
+        text: '데이터 패칭 성공',
+      };
+
       // 응답데이터 {메세지데이터, 페이지네이션}
-      return { messages: data, pagenation };
+      return { messages: data, pagenation, message };
     } catch (err) {
       return err;
     }


### PR DESCRIPTION
# 🚀 구현한 내용 (What was implemented)


- ✨ 주요 기능: Socket.io를 사용한 1대1 채팅 및 HTTP API (채널 개별 조회, 채널 메세지 조회) 구현
- [x] 1대1 채팅 : Socket.io를 사용해 소켓에 접속중인 유저와 1대1 채팅이 가능합니다.
- [x] HTTP API : 채널 개별 조회, 채널 메세지 조회 API를 구현했습니다.

---

# 🤔 논의가 필요한 사항 (Points to discuss)

- [ ] 그룹 채팅 기능 구현 : 그룹 채팅 도입 시 로직에 대한 논의가 필요합니다.

---

# 🖼️ 결과 이미지 (Screenshots)

<!-- 변경된 결과를 확인할 수 있는 스크린샷을 첨부해주세요. -->
| 채널 메세지 조회 (리밋 1로 테스트)              | 채널 개별 조회                  |
|-----------------------------|-----------------------------|
|  ![image](https://github.com/user-attachments/assets/bdbe3440-a99e-4a16-82ec-3c28d5999d7b)   |  ![image](https://github.com/user-attachments/assets/839a9b99-e517-4a14-98f0-fa0513fc9ac7)   |

---

# 🛠️ 추가 수정 필요 사항 (Additional fixes required)

- [ ] 예외처리 : 예외처리가 되어있지 않아 프론트와 협의 후 예외처리를 구현해야합니다.
- [ ] 응답 메세지 : 응답데이터의 message 가 하드코딩되어 있어 최적화가 필요합니다.

---

# 📝 참고 사항 (Additional notes)

https://www.notion.so/API-c1fc8869b5ae4948844ae9b09db33082
위 링크에서 API 명세서 확인 가능합니다.