### PR TITLE
피드 API 완성

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -314,9 +314,10 @@ model UserApplyProject {
 
 model Channel {
   id            Int             @id @default(autoincrement())
-  name          String          @default("default_channel_name")
   active        Boolean         @default(true)
   created_at    DateTime        @default(now())
+  thumbnail_url String?
+  title         String          @default("default_channel_title")
   Channel_users Channel_users[]
   Message       Message[]
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -58,14 +58,15 @@ model Role {
 }
 
 model MyPageProject {
-  id           Int                 @id @default(autoincrement())
-  user_id      Int
-  title        String
-  description  String
-  created_at   DateTime            @default(now())
-  updated_at   DateTime            @updatedAt
-  user         User                @relation(fields: [user_id], references: [id])
-  ProjectLinks MyPageProjectLink[]
+  id                Int                 @id @default(autoincrement())
+  user_id           Int
+  title             String
+  description       String
+  created_at        DateTime            @default(now())
+  updated_at        DateTime            @updatedAt
+  projectProfileUrl String?
+  user              User                @relation(fields: [user_id], references: [id])
+  ProjectLinks      MyPageProjectLink[]
 
   @@index([user_id])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,6 +25,7 @@ model User {
   created_at       DateTime           @default(now())
   updated_at       DateTime           @updatedAt
   password         String?
+  job_detail       String?
   ArtistData       ArtistData[]
   Channel_users    Channel_users[]
   FeedComments     FeedComment[]
@@ -38,7 +39,6 @@ model User {
   MyPageProject    MyPageProject[]
   UserLinks        MyPageUserLink[]
   ProgrammerData   ProgrammerData?
-  MyPageProject    MyPageProject[]
   ProjectPost      ProjectPost[]
   ProjectSaves     ProjectSave[]
   Resume           Resume[]
@@ -58,7 +58,7 @@ model Role {
 }
 
 model MyPageProject {
-  id           Int           @id @default(autoincrement())
+  id           Int                 @id @default(autoincrement())
   user_id      Int
   title        String
   description  String
@@ -67,7 +67,7 @@ model MyPageProject {
   user         User                @relation(fields: [user_id], references: [id])
   ProjectLinks MyPageProjectLink[]
 
-  @@index([user_id], map: "MyPageProject_user_id_idx") // 인덱스 추가
+  @@index([user_id])
 }
 
 model MyPageProjectLink {
@@ -96,10 +96,12 @@ model ProgrammerData {
 }
 
 model ArtistData {
-  id         Int     @id @default(autoincrement())
-  user_id    Int
-  music_url  String
-  user       User    @relation(fields: [user_id], references: [id])
+  id        Int    @id @default(autoincrement())
+  user_id   Int
+  music_url String
+  user      User   @relation(fields: [user_id], references: [id])
+
+  @@index([user_id], map: "ArtistData_user_id_fkey")
 }
 
 model Status {

--- a/src/feed/dto/comment.dto.ts
+++ b/src/feed/dto/comment.dto.ts
@@ -1,7 +1,7 @@
 import { IsString, IsNotEmpty } from 'class-validator';
 
 export class CommentDto {
-  @IsString()
-  @IsNotEmpty()
+  @IsString({ message: '내용은 문자열이어야 합니다.' })
+  @IsNotEmpty({ message: '내용을 입력해주세요' })
   content: string;
 }

--- a/src/feed/dto/feed.dto.ts
+++ b/src/feed/dto/feed.dto.ts
@@ -1,16 +1,16 @@
 import { IsString, IsArray, ArrayNotEmpty, IsNotEmpty } from 'class-validator';
 
 export class FeedDto {
-  @IsString()
-  @IsNotEmpty()
+  @IsString({ message: '제목은 문자열이어야 합니다.' })
+  @IsNotEmpty({ message: '제목을 입력해주세요.' })
   title: string;
 
-  @IsArray()
-  @ArrayNotEmpty()
+  @IsArray({ message: '태그는 배열이어야 합니다.' })
+  @ArrayNotEmpty({ message: '태그를 하나 이상 입력해주세요' })
   @IsString({ each: true })
   tags: string[];
 
-  @IsString()
-  @IsNotEmpty()
+  @IsString({ message: '내용은 문자열이어야 합니다.' })
+  @IsNotEmpty({ message: '내용을 입력해주세요' })
   content: string;
 }

--- a/src/feed/dto/getFeedsQuery.dto.ts
+++ b/src/feed/dto/getFeedsQuery.dto.ts
@@ -19,4 +19,7 @@ export class GetFeedsQueryDto {
   @IsInt()
   @Type(() => Number)
   cursor?: number;
+
+  @IsOptional()
+  tags?: string;
 }

--- a/src/feed/feed.controller.ts
+++ b/src/feed/feed.controller.ts
@@ -121,6 +121,13 @@ export class FeedController {
     return this.feedService.deleteComment(userId, feedId, commentId);
   }
 
+  @Post('comment/:id')
+  @UseGuards(JwtAuthGuard)
+  async handleCommentLikes(@Req() req, @Param('id') commentId: number) {
+    const userId = req.user.user_id;
+    return await this.feedService.handleCommentLikes(userId, commentId);
+  }
+
   // 이미지 업로드
   @Post('image')
   @UseInterceptors(FileInterceptor('file'))

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -23,6 +23,7 @@ export class FeedService {
 
       const result = await this.prisma.feedPost.findMany({
         where: cursor ? { id: { gt: cursor } } : {},
+
         include: {
           Likes: {
             where: { user_id: userId },
@@ -115,6 +116,12 @@ export class FeedService {
       }
 
       const post = await this.getPostObj(result);
+
+      // 조회수 증가
+      await this.prisma.feedPost.update({
+        where: { id: feedId },
+        data: { view: { increment: 1 } },
+      });
 
       return {
         post,

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -174,6 +174,7 @@ export class FeedService {
               profile_url: true,
             },
           },
+          FeedCommentLikes: true,
         },
       });
 
@@ -195,6 +196,7 @@ export class FeedService {
         userProfileUrl: c.user.profile_url,
         comment: c.content,
         createdAt: c.created_at,
+        likes: c.FeedCommentLikes.length,
       }));
 
       return {

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -202,8 +202,8 @@ export class FeedService {
         userRole: c.user.role.name,
         userProfileUrl: c.user.profile_url,
         comment: c.content,
+        likeCount: c.FeedCommentLikes.length,
         createdAt: c.created_at,
-        likes: c.FeedCommentLikes.length,
       }));
 
       return {

--- a/src/feed/feed.service.ts
+++ b/src/feed/feed.service.ts
@@ -500,6 +500,29 @@ export class FeedService {
     return { message: { code: 200, message: '댓글 수정이 완료되었습니다.' } };
   }
 
+  // 댓글 좋아요 추가/제거
+  async handleCommentLikes(userId: number, commentId: number) {
+    // 좋아요 여부 확인
+    const exist = await this.prisma.feedCommentLikes.findMany({
+      where: { user_id: userId, comment_id: commentId },
+    });
+
+    if (exist.length) {
+      // 있을 시 좋아요 제거
+      await this.prisma.feedCommentLikes.deleteMany({
+        where: { user_id: userId, comment_id: commentId },
+      });
+
+      return { message: { code: 200, message: '좋아요가 취소되었습니다.' } };
+    } else {
+      // 없을 시 좋아요 추가
+      await this.prisma.feedCommentLikes.create({
+        data: { user_id: userId, comment_id: commentId },
+      });
+      return { message: { code: 200, message: '좋아요가 추가되었습니다.' } };
+    }
+  }
+
   // 게시글 권한 확인
   async feedAuth(userId: number, feedId: number) {
     const auth = await this.prisma.feedPost.findUnique({


### PR DESCRIPTION
# 🚀 구현한 내용 (What was implemented)

- ✨ 주요 기능: 기존 피드 API 에서 누락된 기능들을 구현했습니다.
  - [x] 댓글 : 좋아요 추가 제거 / 댓글 좋아요 수 응답데이터에 포함
  - [x] 메인 페이지 조회 API에 태그별 게시글 조회 로직 구현
  - [x] 피드 조회 시 조회수 증가 구현
  - [x] DTO 예외메세지 처리

---


# 🛠️ 추가 수정 필요 사항 (Additional fixes required)

- [ ] 스웨거에 각 API들이 명시되어 있지 않아 작업이 필요합니다
- [ ] 프론트에서 연결해보며 오류가 발생하는지 확인해야합니다.

---

# 📝 참고 사항 (Additional notes)

- **참고 자료**: [API 명세서 링크](https://www.notion.so/API-c1fc8869b5ae4948844ae9b09db33082)
